### PR TITLE
Make dependencies BUILD_REQUIRES

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,7 +9,7 @@ BEGIN {
 WriteMakefile(
     'NAME'		=> 'CGI::Expand',
     'VERSION_FROM'	=> 'Expand.pm', # finds $VERSION
-    'PREREQ_PM'		=> {
+    'BUILD_REQUIRES'	=> {
 		'Test::Exception' => 0,
 		'Test::More' => 0,
 	}, # e.g., Module::Name => 1.1


### PR DESCRIPTION
Test modules are not required to use the module, some they should better be listed as BUILD_REQUIRES instead of PREREQ_PM. This is relevant for Test::Exception only (Test::More is core since Perl 5.6.2), if you want to install CGI::Expand without tests (`cpanm --notest CGI::Expand`).
